### PR TITLE
Updated logging for _sanifix4.py

### DIFF
--- a/datamol/_sanifix4.py
+++ b/datamol/_sanifix4.py
@@ -2,9 +2,11 @@
 sanifix4.py
 Original code from rdkit [James Davidson]
 """
-import logging
 
-from rdkit import Chem
+from rdkit import Chem, RDLogger
+
+
+logger = RDLogger.logger()
 
 
 def _FragIndicesToMol(oMol, indices):
@@ -118,16 +120,16 @@ def sanifix(m):
         Chem.SanitizeMol(cp)
         return cp
     except ValueError as e:
-        logging.debug(e, Chem.MolToSmiles(m))
+        logger.debug(f"{Chem.MolToSmiles(m)} failed due to {e}")
         try:
             m = AdjustAromaticNs(m)
             if m is not None:
                 Chem.SanitizeMol(m)
             return m
         except Exception as ee:
-            logging.debug(ee, Chem.MolToSmiles(m))
+            logger.debug(f"{Chem.MolToSmiles(m)} failed due to {ee}")
             return None
     except RuntimeError as e:
-        logging.debug(e, Chem.MolToSmiles(m))
-        logging.info("The faulty smiles is: {}".format(Chem.MolToSmiles(m)))
+        logger.debug(f"{Chem.MolToSmiles(m)} failed due to {e}")
+        logger.info(f"The faulty smiles is: {Chem.MolToSmiles(m)}")
         raise e

--- a/news/fix-sanifix-logging.rst
+++ b/news/fix-sanifix-logging.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Updated the logging in `_sanifix4.py` to use the RDKit logger
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Checklist:

- [ ] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
- [X] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

I noticed that in rare occasions, sanitizing a molecule could fail due to seemingly outdated usage of the logging module in `_sanifix4.py`. I propose to use the RDKit logger instead, because to me personally this code logically falls under RDKit and so that verbosity can be controlled through Datamol's `dm.without_rdkit_log()` context manager. 

Example in which logging could go wrong: 
```python
import datamol as dm
import numpy as np
import autosklearn.regression

smi = '[NH4][Pt]([NH4])(Cl)Cl'
mol = dm.to_mol(smi, ordered=True, sanitize=False)
mol = dm.sanitize_mol(mol)  # This will throw the normal warnings as expected

X = np.random.random((100, 10))
y = np.random.random((100, 1))

# AutoML configures the logging module
obj = autosklearn.regression.AutoSklearnRegressor(time_left_for_this_task=30)
obj.fit(X, y)

mol = dm.to_mol(smi, ordered=True, sanitize=False)
mol = dm.sanitize_mol(mol)  # This will now throw a logging error
```
