### PR TITLE
Change the docs style with navigation tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ theme:
   # NOTE(hadim): to customize the material primary and secondary
   # color check `docs/assets/css/datamol-custom.css`.
   features:
+    - navigation.tabs
     - navigation.expand
   favicon: images/logo-black.png
   logo: images/logo.svg

--- a/news/docs_style.rst
+++ b/news/docs_style.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Different docs style, with Tabs on the top for `Overview`, `Usage`, `Tutorials`, `API`, `Contribute`, `License`


### PR DESCRIPTION
The old docs API is too messy with too many things on the left.
![image](https://user-images.githubusercontent.com/47570400/235508462-6483b8d3-bafb-4549-8571-dfdbdd15672a.png)

Most modern libraries use tabs at the top to organize, making the API a lot easier to follow.
![image](https://user-images.githubusercontent.com/47570400/235508511-c6c8442f-57de-4098-a200-4cb99ae6e14b.png)


Checklist:

- [ ] Was this PR discussed in a issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR. 
  - No, it's a single line of code
- [ ] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
  - Not needed
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
  - Not needed
- [x] Added a `news` entry.

---
