### PR TITLE
fuzzy_scaffold can now return a pandas dataframe that is more readable.

### DIFF
--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Any
 from typing import Tuple
 from typing import Optional
+from typing import Union
 
 import collections
 import itertools
@@ -81,8 +82,8 @@ def fuzzy_scaffolding(
     additional_templates: Optional[List[Mol]] = None,
     ignore_non_ring: bool = False,
     mcs_params: Optional[Dict[Any, Any]] = None,
-    if_df: bool = False,
-) -> Tuple[set, Dict[str, dict], Dict[str, list]] | Tuple[set, pd.DataFrame, pd.DataFrame]:
+    if_df: bool = True,
+) -> Union[Tuple[set, Dict[str, dict], Dict[str, list]], Tuple[set, pd.DataFrame, pd.DataFrame]]:
     """Generate fuzzy scaffold with enforceable group that needs to appear
     in the core, forcing to keep the full side chain if required
 

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -231,16 +231,27 @@ def fuzzy_scaffolding(
             except:
                 continue
             all_scaffolds.add(to_smiles(scaff))
-
         #if user wants a dataframe turned on...
         #there are processing routines to make the df more readable.
-        if if_df:
+    if if_df:
 
-            #the way scf2infos is created is absolutely perfect 
-            #to be pandas transposed. Every murkold scaffold output has its corresponding
-            #"matched" input rdkit mol and its smarts pattern.  
-            df_infos = pd.DataFrame(scf2infos)
-            df_infos_t = df_infos.transpose()
-            
-            return all_scaffolds, df_infos_t, df_groups_t
+        #the way scf2infos is created is absolutely perfect 
+        #to be pandas transposed. Every Murcko scaffold output has its corresponding
+        #"matched" input rdkit mol and its smarts pattern. 
+        # This means every row will represent the scffold and every col
+        # will have its "matched" mol 
+        df_infos = pd.DataFrame(scf2infos)
+        df_infos_t = df_infos.transpose()
+
+        # scf2groups is trickier because the core 'groups' are in their individual
+        # dictionaries contained in a list. This can be difficult to create a df due 
+        # to these multi-valued attributes. Thankfully, Pandas can control 
+        # for the multi-valued attributes by calling from the .from_dict method 
+        # and setting orient to 'index'. While 'index' turns the keys of 
+        # the scf2groups into df rows, you can transpose to turn them into 
+        # column values so the each scf can be accessed by key again. 
+        df_groups_t = pd.DataFrame.from_dict(scf2groups, orient='index')
+        df_groups_t = df_groups_t.transpose()
+        
+        return all_scaffolds, df_infos_t, df_groups_t
     return all_scaffolds, scf2infos, scf2groups

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -231,41 +231,39 @@ def fuzzy_scaffolding(
             except:
                 continue
             all_scaffolds.add(to_smiles(scaff))
-        #if user wants a dataframe turned on...
-        #there are processing routines to make the df more readable.
+        # if user wants a dataframe turned on...
+        # there are processing routines to make the df more readable.
     if if_df:
-
-        #the way scf2infos is created is absolutely perfect 
-        #to be pandas transposed. Every Murcko scaffold output has its corresponding
-        #"matched" input rdkit mol and its smarts pattern. 
+        # the way scf2infos is created is absolutely perfect
+        # to be pandas transposed. Every Murcko scaffold output has its corresponding
+        # "matched" input rdkit mol and its smarts pattern.
         # This means every row will represent the scffold and every col
-        # will have its "matched" mol 
+        # will have its "matched" mol
 
         df_infos = pd.DataFrame(scf2infos)
         df_infos_t = df_infos.transpose()
-        df_infos_t.insert(0,'scf', list(scf2infos.keys()), True)
+        df_infos_t.insert(0, "scf", list(scf2infos.keys()), True)
         df_infos_t.reset_index(inplace=True, drop=True)
 
-        #relabel index and column labels to
-        #damp down confusion
-        df_infos_t.index.name = 'index'
-        # df_infos_t.rename(columns = {'mols': 'core_groups_mols'}, inplace = True)
+        # relabel index and column labels to
+        # to be more readable
+        df_infos_t.index.name = "index"
 
         # scf2groups is trickier because the core 'groups' are in their individual
-        # dictionaries contained in a list. This can be difficult to create a df due 
-        # to these multi-valued attributes. Thankfully, Pandas can control 
-        # for the multi-valued attributes by calling from the .from_dict method 
+        # dictionaries contained in a list. This can be difficult to create a df due
+        # to these multi-valued attributes. Thankfully, Pandas can control
+        # for the multi-valued attributes by calling from the .from_dict method
         # and setting orient to 'index'.
-        df_groups = pd.DataFrame.from_dict(scf2groups, orient='index')
+        df_groups = pd.DataFrame.from_dict(scf2groups, orient="index")
         df_groups.reset_index(inplace=True, drop=True)
 
-        #relabel index and column labels to
-        #damp down confusion
-        df_groups.index.name = 'index'
-        df_groups.columns = [f'{str(h)}_core_group' for h in df_groups.columns]
+        # relabel index and column labels to
+        # to be more readable
+        df_groups.index.name = "index"
+        df_groups.columns = [f"{str(h)}_core_group" for h in df_groups.columns]
 
-        #enter the scf columns at the first column
-        df_groups.insert(0,'scf', list(scf2groups.keys()), True)
-        
+        # enter the scf columns at the first column for df_groups
+        df_groups.insert(0, "scf", list(scf2groups.keys()), True)
+
         return all_scaffolds, df_infos_t, df_groups
     return all_scaffolds, scf2infos, scf2groups

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import collections
 import itertools
+import pandas as pd
 
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
@@ -80,7 +81,8 @@ def fuzzy_scaffolding(
     additional_templates: Optional[List[Mol]] = None,
     ignore_non_ring: bool = False,
     mcs_params: Optional[Dict[Any, Any]] = None,
-) -> Tuple[set, Dict[str, dict], Dict[str, list]]:
+    if_df: bool = False,
+) -> Tuple[set, Dict[str, dict], Dict[str, list]] or Tuple[set, pd.DataFrame, pd.DataFrame]:
     """Generate fuzzy scaffold with enforceable group that needs to appear
     in the core, forcing to keep the full side chain if required
 
@@ -91,6 +93,7 @@ def fuzzy_scaffolding(
         additional_templates: Additional template to use to generate scaffolds.
         ignore_non_ring: Whether to ignore atom no in murcko ring system, even if they are in the framework.
         mcs_params: Arguments of MCS algorithm.
+        if_df: Turn on true if you want to return data frames for scaffold_infos and scaffold_to_group
 
     Returns:
         - `set` - `scaffolds` - All found scaffolds in the molecules as valid smiles.
@@ -229,4 +232,15 @@ def fuzzy_scaffolding(
                 continue
             all_scaffolds.add(to_smiles(scaff))
 
+        #if user wants a dataframe turned on...
+        #there are processing routines to make the df more readable.
+        if if_df:
+
+            #the way scf2infos is created is absolutely perfect 
+            #to be pandas transposed. Every murkold scaffold output has its corresponding
+            #"matched" input rdkit mol and its smarts pattern.  
+            df_infos = pd.DataFrame(scf2infos)
+            df_infos_t = df_infos.transpose()
+            
+            return all_scaffolds, df_infos_t, df_groups_t
     return all_scaffolds, scf2infos, scf2groups

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -82,7 +82,7 @@ def fuzzy_scaffolding(
     ignore_non_ring: bool = False,
     mcs_params: Optional[Dict[Any, Any]] = None,
     if_df: bool = False,
-) -> Tuple[set, Dict[str, dict], Dict[str, list]] or Tuple[set, pd.DataFrame, pd.DataFrame]:
+) -> Tuple[set, Dict[str, dict], Dict[str, list]] | Tuple[set, pd.DataFrame, pd.DataFrame]:
     """Generate fuzzy scaffold with enforceable group that needs to appear
     in the core, forcing to keep the full side chain if required
 

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -102,6 +102,12 @@ def fuzzy_scaffolding(
                 Values at ['smarts'] corresponds to smarts representation of the true scaffold (from MCS)
                 Values at ['mols'] corresponds to list of molecules matching the scaffold
         - `Dict[List]` - `scaffold_to_group` - Map between each generic scaffold and the R-groups decomposition row.
+        - `pd.DataFrame` - `df_scaffold_infos_transposed` - A pandas dataframe with Infos on the scaffold mapping, ignoring
+            any side chain that had to be enforced. Key corresponds to generic scaffold smiles.
+            Values at ['smarts'] corresponds to smarts representation of the true scaffold (from MCS)
+            Values at ['mols'] corresponds to list of molecules matching the scaffold
+        - `pd.DataFrame` - `df_scaffold_groups` - A pandas dataframe with Map between each generic scaffold
+            and the R-groups decomposition row.
     """
 
     # NOTE(hadim): consider parallelize this (if possible).
@@ -234,12 +240,6 @@ def fuzzy_scaffolding(
         # if user wants a dataframe turned on...
         # there are processing routines to make the df more readable.
     if if_df:
-        # the way scf2infos is created is absolutely perfect
-        # to be pandas transposed. Every Murcko scaffold output has its corresponding
-        # "matched" input rdkit mol and its smarts pattern.
-        # This means every row will represent the scffold and every col
-        # will have its "matched" mol
-
         df_infos = pd.DataFrame(scf2infos)
         df_infos_t = df_infos.transpose()
         df_infos_t.insert(0, "scf", list(scf2infos.keys()), True)
@@ -249,11 +249,6 @@ def fuzzy_scaffolding(
         # to be more readable
         df_infos_t.index.name = "index"
 
-        # scf2groups is trickier because the core 'groups' are in their individual
-        # dictionaries contained in a list. This can be difficult to create a df due
-        # to these multi-valued attributes. Thankfully, Pandas can control
-        # for the multi-valued attributes by calling from the .from_dict method
-        # and setting orient to 'index'.
         df_groups = pd.DataFrame.from_dict(scf2groups, orient="index")
         df_groups.reset_index(inplace=True, drop=True)
 

--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -240,18 +240,32 @@ def fuzzy_scaffolding(
         #"matched" input rdkit mol and its smarts pattern. 
         # This means every row will represent the scffold and every col
         # will have its "matched" mol 
+
         df_infos = pd.DataFrame(scf2infos)
         df_infos_t = df_infos.transpose()
+        df_infos_t.insert(0,'scf', list(scf2infos.keys()), True)
+        df_infos_t.reset_index(inplace=True, drop=True)
+
+        #relabel index and column labels to
+        #damp down confusion
+        df_infos_t.index.name = 'index'
+        # df_infos_t.rename(columns = {'mols': 'core_groups_mols'}, inplace = True)
 
         # scf2groups is trickier because the core 'groups' are in their individual
         # dictionaries contained in a list. This can be difficult to create a df due 
         # to these multi-valued attributes. Thankfully, Pandas can control 
         # for the multi-valued attributes by calling from the .from_dict method 
-        # and setting orient to 'index'. While 'index' turns the keys of 
-        # the scf2groups into df rows, you can transpose to turn them into 
-        # column values so the each scf can be accessed by key again. 
-        df_groups_t = pd.DataFrame.from_dict(scf2groups, orient='index')
-        df_groups_t = df_groups_t.transpose()
+        # and setting orient to 'index'.
+        df_groups = pd.DataFrame.from_dict(scf2groups, orient='index')
+        df_groups.reset_index(inplace=True, drop=True)
+
+        #relabel index and column labels to
+        #damp down confusion
+        df_groups.index.name = 'index'
+        df_groups.columns = [f'{str(h)}_core_group' for h in df_groups.columns]
+
+        #enter the scf columns at the first column
+        df_groups.insert(0,'scf', list(scf2groups.keys()), True)
         
-        return all_scaffolds, df_infos_t, df_groups_t
+        return all_scaffolds, df_infos_t, df_groups
     return all_scaffolds, scf2infos, scf2groups

--- a/news/my-feature-or-branch.rst
+++ b/news/my-feature-or-branch.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* fuzzy_scaffold can now return a pandas dataframe (when flagged) that is more readable.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -13,7 +13,7 @@ def test_fuzzy_scaffolding():
     ]
 
     mols = [dm.to_mol(s) for s in smiles]
-    all_scaffolds, scf2infos, scf2groups = dm.scaffold.fuzzy_scaffolding(mols)
+    all_scaffolds, scf2infos, scf2groups = dm.scaffold.fuzzy_scaffolding(mols, if_df=False)
 
     assert scf2infos.keys() == scf2groups.keys()
     assert len(all_scaffolds) == 5
@@ -24,7 +24,7 @@ def test_fuzzy_scaffolding():
     # assert "O=C(CSCc1cccs1)NC(C1CCCO1)[*:1]" in all_scaffolds
     # assert "O=C(N=c1sccn1[*:1])C(Oc1ccc([*:3])cc1)[*:2]" in all_scaffolds
 
-    all_scaffolds, df_scf2infos, df_scf2groups = dm.scaffold.fuzzy_scaffolding(mols, if_df=True)
+    all_scaffolds, df_scf2infos, df_scf2groups = dm.scaffold.fuzzy_scaffolding(mols)
 
     assert len(all_scaffolds) == 5
     assert len(df_scf2infos.columns) == 3

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -13,10 +13,6 @@ def test_fuzzy_scaffolding():
     ]
 
     mols = [dm.to_mol(s) for s in smiles]
-    all_scaffolds, scf2infos, scf2groups = dm.scaffold.fuzzy_scaffolding(mols, if_df=False)
-
-    assert scf2infos.keys() == scf2groups.keys()
-    assert len(all_scaffolds) == 5
 
     # NOTE(hadim): different version of rdkit (2020.09 vs 2021.03) returns
     # different SMILES here.
@@ -38,9 +34,3 @@ def test_fuzzy_scaffolding():
     # the same length. the reason there are 3 not two is because it could have
     # extra columns where a cell may have none values.
     assert len(df_scf2groups.columns) == 3
-
-    # now compare to the original output
-    assert list(df_scf2infos["scf"]) == list(scf2infos.keys())
-    assert list(df_scf2groups["scf"]) == list(scf2groups.keys())
-    assert df_scf2groups.set_index("scf").T.to_dict("list").keys() == scf2groups.keys()
-    assert df_scf2infos.set_index("scf").T.to_dict("list").keys() == scf2infos.keys()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,4 +1,5 @@
 import datamol as dm
+import pandas as pd
 
 
 def test_fuzzy_scaffolding():
@@ -8,6 +9,7 @@ def test_fuzzy_scaffolding():
         "CC(NC(=O)CSCc1cccs1)C1CCCO1",
         "CC1CCCCN1C(=O)CN1CCC[C@@H](N)C1",
         "CCC(CC)COC(=O)[C@H](C)N[P@](=O)(OC[C@H]1O[C@](C#N)([C@H](O)[C@@H]1O)C1=CC=C2N1N=CN=C2N)OC1=CC=CC=C1",  # no way this one (Remdesivir) is in the db
+        "COc1ccc(OC(C)C(=O)N=c2sccn2C)cc1",
     ]
 
     mols = [dm.to_mol(s) for s in smiles]
@@ -21,3 +23,24 @@ def test_fuzzy_scaffolding():
     # assert "O=C(CN1CCC[C@@H]([*:1])C1)N1CCCCC1[*:2]" in all_scaffolds
     # assert "O=C(CSCc1cccs1)NC(C1CCCO1)[*:1]" in all_scaffolds
     # assert "O=C(N=c1sccn1[*:1])C(Oc1ccc([*:3])cc1)[*:2]" in all_scaffolds
+
+    all_scaffolds, df_scf2infos, df_scf2groups = dm.scaffold.fuzzy_scaffolding(mols, if_df=True)
+
+    assert len(all_scaffolds) == 5
+    assert len(df_scf2infos.columns) == 3
+
+    # because we are returning the output for each scf
+    # these should be the same
+    assert len(df_scf2infos.index) == len(df_scf2groups.index)
+    assert list(df_scf2infos["scf"]) == list(df_scf2groups["scf"])
+
+    # mere coincidence that scf2infos and scf2groups for the columns have the
+    # the same length. the reason there are 3 not two is because it could have
+    # extra columns where a cell may have none values.
+    assert len(df_scf2groups.columns) == 3
+
+    # now compare to the original output
+    assert list(df_scf2infos["scf"]) == list(scf2infos.keys())
+    assert list(df_scf2groups["scf"]) == list(scf2groups.keys())
+    assert df_scf2groups.set_index("scf").T.to_dict("list").keys() == scf2groups.keys()
+    assert df_scf2infos.set_index("scf").T.to_dict("list").keys() == scf2infos.keys()


### PR DESCRIPTION
Hello!  This is for issue #114.  So this edit is quite opinionated. I don't know if you guys would this kind of organized dataframe. But first I have to discuss where I added this change. I decided to add a optional flag for datamol users in the `fuzzy_scaffolding` function. <strike>The flag is termed `if_df`, which is defaulted to `False`. </strike> The flag is termed `if_df`, which is defaulted to `True`.  **Two** separate pandas dataframe for each `scf2infos` and `scf2groups` will be returned. The rationale is not to confuse users on how `fuzzy_scaffolding` function would return previously.

NOTE: the output below is my best attempt to express the pandas dataframe. The output is just a df that has `3` columns and not `15` rows.

### Let's start with `scf2infos`

The way scf2infos is structured is absolutely perfect to be pandas transposed. Every scaffold output has its corresponding rdkit `mol` list and its `smarts` pattern. This means every row will represent the `scf` and every `scf` will have its `mol` list.

output:
```
                                         scf  \
index                                          
0                      CC(CC1CCCCC1)CC1CCCC1   
1                     CC(CCC1CCCCC1)CC1CCCC1   
2                    CC(CCCC1CCCC1)CCC1CCCC1   
3                      CC(CC1CCCCC1)C1CCCCC1   
4      CC(CCC1CCC(C2CCC3CCCCC32)C1)CC1CCCCC1   

                                                    mols  \
index                                                      
0        [<rdkit.Chem.rdchem.Mol object at 0x1108a1a80>]   
1      [<rdkit.Chem.rdchem.Mol object at 0x1108a06d0>...   
2        [<rdkit.Chem.rdchem.Mol object at 0x1108a0200>]   
3        [<rdkit.Chem.rdchem.Mol object at 0x1108a2dc0>]   
4        [<rdkit.Chem.rdchem.Mol object at 0x1108a2c00>]   

                                                  smarts  
index                                                     
0      [#6]1:&@[#6]:&@[#6]:&@[#6](:&@[#6]:&@[#6]:&@1)...  
1      [#6]-&!@[#8]-&!@[#6]1:&@[#6]:&@[#6]:&@[#6](:&@...  
2      [#6](-&!@[#7]-&!@[#6](=&!@[#8])-&!@[#6]-&!@[#1...  
3      [#6]1-&@[#6]-&@[#6]-&@[#6]-&@[#6]-&@[#7]-&@1-&...  
4      [#15](=,-;!@[#8,#7])(-&!@[#8]-&!@[#6]-&!@[#6]1...  
```



### What about `scf2groups`?

scf2groups is trickier because the core 'groups' are in their individual dictionaries contained in a list. This can be difficult to create a df due to these multi-valued attributes. Thankfully, Pandas can control for the multi-valued attributes by calling from the `.from_dict()` method and setting `orient` to `'index'`. Further, this allows the df for each `scf` row to have `None` values if there are no results. So this df will dynamically create `n_core_group`s if there is an output with `n` number of core groups. So in the case below, `scf` index `1` has two core groups but the rest do not. 

```
                                         scf  \
index                                          
0                      CC(CC1CCCCC1)CC1CCCC1   
1                     CC(CCC1CCCCC1)CC1CCCC1   
2                    CC(CCCC1CCCC1)CCC1CCCC1   
3                      CC(CC1CCCCC1)C1CCCCC1   
4      CC(CCC1CCC(C2CCC3CCCCC32)C1)CC1CCCCC1   

                                            0_core_group  \
index                                                      
0      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...   
1      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...   
2      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...   
3      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...   
4      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...   

                                            1_core_group  
index                                                     
0                                                   None  
1      {'Core': <rdkit.Chem.rdchem.Mol object at 0x11...  
2                                                   None  
3                                                   None  
4                                                   None  
```

Other than that. I hope you like the code. I also updated the test cases. 

Thanks, 
Steven Pak

Checklist:

- [x] Was this PR discussed in a issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR. 
- [x] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
- [x] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---


