### PR TITLE
fix zero division error in conformers

### DIFF
--- a/datamol/conformers/_conformers.py
+++ b/datamol/conformers/_conformers.py
@@ -91,7 +91,8 @@ def generate(
             ["ETDG", "ETKDG", "ETKDGv2", "ETKDGv3"]. If None, "ETKDGv3" is used.
         forcefield: molecular forcefield to use, one of ['UFF','MMFF94s','MMFF94s_noEstat']
         ewindow: maximum energy above minimum energy conformer to output
-        eratio: max delta-energy divided by rotatable bonds for conformers
+        eratio: max delta-energy divided by rotatable bonds for conformers.
+            Ignored if the molecule has no rotatable bonds.
         energy_iterations: Maximum number of iterations during the energy minimization procedure.
             It corresponds to the `maxIters` argument in RDKit.
         warning_not_converged: Wether to log a warning when the number of not converged conformers
@@ -211,7 +212,8 @@ def generate(
         ordered_conformers = [
             conf
             for E, conf in sorted(zip(energies, mol_clone.GetConformers()), key=lambda x: x[0])
-            if E - minE <= ewindow and (E - minE) / rotatable_bonds <= eratio
+            if E - minE <= ewindow
+            and (rotatable_bonds == 0 or (E - minE) / rotatable_bonds <= eratio)
         ]
         mol.RemoveAllConformers()
         [mol.AddConformer(conf, assignId=True) for conf in ordered_conformers]

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -326,6 +326,7 @@ def test_conformer_energy():
     assert np.isclose(e3["rdkit_MMFF94s_noEstat_energy"], 38.217380, atol=1)
     assert np.isclose(e3["rdkit_MMFF94s_noEstat_delta_energy"], 0.0, atol=0.1)
 
+
 def test_conformer_no_rotatable_bonds():
     mol = dm.to_mol("c1ccccc1")
 

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -325,3 +325,17 @@ def test_conformer_energy():
     e3 = mol3.GetConformer(3).GetPropsAsDict()
     assert np.isclose(e3["rdkit_MMFF94s_noEstat_energy"], 38.217380, atol=1)
     assert np.isclose(e3["rdkit_MMFF94s_noEstat_delta_energy"], 0.0, atol=0.1)
+
+def test_conformer_no_rotatable_bonds():
+    mol = dm.to_mol("c1ccccc1")
+
+    random.seed(42)
+    np.random.seed(42)
+    mol1 = dm.conformers.generate(mol, minimize_energy=True)
+
+    random.seed(42)
+    np.random.seed(42)
+    mol2 = dm.conformers.generate(mol, minimize_energy=True, eratio=3)
+
+    # `eratio` should be ignored for this molecule as it has no rotatable bonds
+    assert mol1.GetNumConformers() == mol2.GetNumConformers()

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -34,9 +34,9 @@ def test_esol_from_data():
     # series
     v = dm.predictors.esol_from_data(data.iloc[0])
     v = float(v)
-    assert type(v) == float
+    assert isinstance(v, float)
 
     # dict
     v = dm.predictors.esol_from_data(data.iloc[0].to_dict())
     v = float(v)
-    assert type(v) == float
+    assert isinstance(v, float)


### PR DESCRIPTION
## Changelogs

- Fixed a division-by-zero error in `dm.conformers.generate()` when `minimize_energy` is set to `True` and the molecule has no rotatable bonds. Below is a minimal example that reproduces the error:

  ```python
  import datamol as dm

  mol = dm.to_mol("c1ccccc1")
  dm.conformers.generate(mol, minimize_energy=True)
  ```

  Error message:
  ```
  /workspaces/datamol/datamol/conformers/_conformers.py:214: RuntimeWarning: invalid value encountered in scalar divide
  if E - minE <= ewindow and (E - minE) / rotatable_bonds <= eratio
  /workspaces/datamol/datamol/conformers/_conformers.py:214: RuntimeWarning: divide by zero encountered in scalar divide
    if E - minE <= ewindow and (E - minE) / rotatable_bonds <= eratio
  ```

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs below._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
