### PR TITLE
Fix ResourceWarning due to unclosed file

### DIFF
--- a/datamol/data/__init__.py
+++ b/datamol/data/__init__.py
@@ -27,15 +27,17 @@ from ..io import read_sdf
 from ..convert import from_df
 from ..convert import render_mol_df
 
+
 @functools.lru_cache()
 def datamol_data_file_path(filename: str, dm_module: str = "datamol.data") -> str:
     if sys.version_info < (3, 9, 0):
-        with importlib_resources.path("datamol.data", filename) as p:
+        with importlib_resources.path(dm_module, filename) as p:
             data_path = p
     else:
         data_path = importlib_resources.files(dm_module).joinpath(filename)
 
     return str(data_path)
+
 
 def open_datamol_data_file(
     filename: str,

--- a/datamol/data/__init__.py
+++ b/datamol/data/__init__.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 import sys
 import io
+import functools
 
 try:
     import importlib.resources as importlib_resources
@@ -26,6 +27,15 @@ from ..io import read_sdf
 from ..convert import from_df
 from ..convert import render_mol_df
 
+@functools.lru_cache()
+def datamol_data_file_path(filename: str, dm_module: str = "datamol.data") -> str:
+    if sys.version_info < (3, 9, 0):
+        with importlib_resources.path("datamol.data", filename) as p:
+            data_path = p
+    else:
+        data_path = importlib_resources.files(dm_module).joinpath(filename)
+
+    return str(data_path)
 
 def open_datamol_data_file(
     filename: str,

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -45,8 +45,7 @@ SINGLE_BOND = Chem.rdchem.BondType.SINGLE
 AROMATIC_BOND = Chem.rdchem.BondType.AROMATIC
 DATIVE_BOND = Chem.rdchem.BondType.DATIVE
 UNSPECIFIED_BOND = Chem.rdchem.BondType.UNSPECIFIED
-with datamol.data.open_datamol_data_file("salts_solvents.smi") as file_obj:
-    SALT_SOLVENT_PATH = file_obj.name
+SALT_SOLVENT_PATH = datamol.data.datamol_data_file_path("salts_solvents.smi")
 SALT_SOLVENT_REMOVER = SaltRemover(defnFilename=SALT_SOLVENT_PATH)
 
 

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -45,7 +45,8 @@ SINGLE_BOND = Chem.rdchem.BondType.SINGLE
 AROMATIC_BOND = Chem.rdchem.BondType.AROMATIC
 DATIVE_BOND = Chem.rdchem.BondType.DATIVE
 UNSPECIFIED_BOND = Chem.rdchem.BondType.UNSPECIFIED
-SALT_SOLVENT_PATH = datamol.data.open_datamol_data_file("salts_solvents.smi").name
+with datamol.data.open_datamol_data_file("salts_solvents.smi") as file_obj:
+    SALT_SOLVENT_PATH = file_obj.name
 SALT_SOLVENT_REMOVER = SaltRemover(defnFilename=SALT_SOLVENT_PATH)
 
 


### PR DESCRIPTION
## Changelogs
closes #211 
- _enumerate the changes of that PR._
This PR addresses a ResourceWarning that was being raised due to an unclosed file in datamol/mol.py. The warning was triggered by the following line of code:
```python
SALT_SOLVENT_PATH = datamol.data.open_datamol_data_file("salts_solvents.smi").name
```

This line opens a file but does not close it, which is why the ResourceWarning was being raised. To resolve this issue, I've modified the line to use a with block, which ensures that the file is properly closed after its name is retrieved:

```python
with datamol.data.open_datamol_data_file("salts_solvents.smi") as file_obj:
    SALT_SOLVENT_PATH = file_obj.name
```

This change should prevent the ResourceWarning from being raised in the future. I've tested the change locally and confirmed that it resolves the warning without causing any other issues.

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [ ] _Write concise and explanatory changelogs below._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
