### PR TITLE
Added function to get the number of stereoisomers

### DIFF
--- a/datamol/__init__.py
+++ b/datamol/__init__.py
@@ -135,6 +135,7 @@ _lazy_imports_obj = {
     "save_df": "datamol.io",
     # isomers
     "enumerate_stereoisomers": "datamol.isomers",
+    "count_stereoisomers": "datamol.isomers",
     "enumerate_tautomers": "datamol.isomers",
     "enumerate_structisomers": "datamol.isomers",
     "canonical_tautomer": "datamol.isomers",
@@ -329,6 +330,7 @@ if TYPE_CHECKING or os.environ.get("DATAMOL_DISABLE_LAZY_LOADING", "0") == "1":
     from .io import open_df
 
     from .isomers import enumerate_stereoisomers
+    from .isomers import count_stereoisomers
     from .isomers import enumerate_tautomers
     from .isomers import enumerate_structisomers
     from .isomers import canonical_tautomer

--- a/datamol/isomers/__init__.py
+++ b/datamol/isomers/__init__.py
@@ -3,5 +3,6 @@ from ._structural import IsomerEnumerator
 from ._enumerate import enumerate_stereoisomers
 from ._enumerate import enumerate_tautomers
 from ._enumerate import enumerate_structisomers
+from ._enumerate import count_stereoisomers
 from ._enumerate import remove_stereochemistry
 from ._enumerate import canonical_tautomer

--- a/datamol/isomers/_enumerate.py
+++ b/datamol/isomers/_enumerate.py
@@ -140,7 +140,9 @@ def count_stereoisomers(
 
     # in case any bonds/centers are missing stereo chem flag it here
     Chem.AssignStereochemistry(mol, force=False, flagPossibleStereoCenters=True, cleanIt=clean_it)  # type: ignore
-    Chem.FindPotentialStereoBonds(mol, cleanIt=clean_it)  # type: ignore
+    # lu: this impac the result when `undefined_only` set to True
+    if not undefined_only:
+        Chem.FindPotentialStereoBonds(mol, cleanIt=clean_it)
 
     # set up the options
     stereo_opts = StereoEnumerationOptions(

--- a/tests/test_isomers.py
+++ b/tests/test_isomers.py
@@ -42,6 +42,12 @@ def test_enumerate_stereo_timeout():
     # machines so we here we just check the code can run without errors
     dm.enumerate_stereoisomers(mol, n_variants=2, timeout_seconds=1)
 
+def test_count_stereoisomers():
+    num_isomers_1 = dm.count_stereoisomers(dm.to_mol("CC=CC"), undefined_only=True)
+    num_isomers_2 = dm.count_stereoisomers(dm.to_mol("CC=CC"), undefined_only=False)
+    assert num_isomers_1 == num_isomers_2
+
+    assert dm.count_stereoisomers(dm.to_mol('Br/C=C\\Br'), undefined_only=True) == 1
 
 def test_enumerate_structural():
     mol = dm.to_mol("CCCCC")  # pentane has only three structural isomers


### PR DESCRIPTION
## Changelogs

- Added `datamol.isomers._enumerate.count_stereoisomers`
- Added unit tests to count stereoisomers for only undefined and all possible stereoisomers.
---

The step [`Chem.FindPotentialStereoBonds(mol, cleanIt=clean_it)`](https://github.com/datamol-io/datamol/blob/9e94d026534b2a534250dfbfab924ab6f089e477/datamol/isomers/_enumerate.py#L85),   the information on bond is cleared if `cleanit=True`.
Therefore,  `cleanit` should be disabled when performing enumeration or counting only on undefined stereochemistry when the molecules have defined stereo information on bonds.

See example below:
![image](https://github.com/datamol-io/datamol/assets/6717019/a857da07-e93a-4073-a1e7-eb131a477ace)

Reproduce the error
```
import datamol as dm
from rdkit import Chem

from rdkit.Chem.EnumerateStereoisomers import GetStereoisomerCount, StereoEnumerationOptions, EnumerateStereoisomers
n_variants= 20
undefined_only= True # <-
rationalise = True
timeout_seconds= None
clean_it= True
stereo_opts = StereoEnumerationOptions(
        tryEmbedding=rationalise,
        onlyUnassigned=undefined_only,
        unique=True,
    )
mol  = dm.to_mol('Br/C=C\Br')
Chem.AssignStereochemistry(mol, force=False, flagPossibleStereoCenters=True, cleanIt=clean_it)  # type: ignore
Chem.FindPotentialStereoBonds(mol, cleanIt=clean_it)  # type: ignore
dm.to_image(list(EnumerateStereoisomers(mol, options=stereo_opts)))
```