### PR TITLE
Add rdkit as a pypi dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ site/
 
 .idea/
 __pycache__
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,7 @@ dependencies = [
     "packaging",
     "typing-extensions",
     "importlib-resources",
-    # NOTE(hadim): can't add rdkit because of `pip` will always override
-    # the conda package at the moment.
-    # See:
-    # - https://github.com/rdkit/rdkit/issues/5378
-    # - https://github.com/conda-forge/rdkit-feedstock/issues/104
-    # "rdkit",
+    "rdkit",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Changelogs

- Add rdkit as a pypi dep. Now possible after the rdkit conda package fix at https://github.com/conda-forge/rdkit-feedstock/pull/143

---

_Checklist:_

- [ ] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs below._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
