### PR TITLE
fix: add lasso colors for atom_indices

### DIFF
--- a/datamol/__init__.py
+++ b/datamol/__init__.py
@@ -4,7 +4,6 @@ import os
 
 import importlib
 
-
 # The below lazy import logic is coming from openff-toolkit:
 # https://github.com/openforcefield/openff-toolkit/blob/b52879569a0344878c40248ceb3bd0f90348076a/openff/toolkit/__init__.py#L44
 

--- a/datamol/_sanifix4.py
+++ b/datamol/_sanifix4.py
@@ -5,7 +5,6 @@ Original code from rdkit [James Davidson]
 
 from rdkit import Chem, RDLogger
 
-
 logger = RDLogger.logger()
 
 

--- a/datamol/_version.py
+++ b/datamol/_version.py
@@ -10,7 +10,6 @@ except ModuleNotFoundError:
 import rdkit
 import packaging.version
 
-
 try:
     __version__ = version("datamol")
 except PackageNotFoundError:

--- a/datamol/descriptors/descriptors.py
+++ b/datamol/descriptors/descriptors.py
@@ -19,7 +19,7 @@ from .._version import is_lower_than_current_rdkit_version
 def _sasscorer(mol: Mol):
     sys.path.append(os.path.join(RDConfig.RDContribDir, "SA_Score"))
     try:
-        import sascorer  # type:ignore
+        import sascorer  # type: ignore
     except ImportError:
         raise ImportError(
             "Could not import sascorer. If you installed rdkit-pypi with `pip`, please uninstall it and reinstall rdkit with `conda` or `mamba`."

--- a/datamol/fp.py
+++ b/datamol/fp.py
@@ -190,7 +190,7 @@ _FP_DEFAULT_ARGS = {
 
 
 def fp_to_array(
-    fp: Union[np.ndarray, SparseBitVect, ExplicitBitVect, UIntSparseIntVect]
+    fp: Union[np.ndarray, SparseBitVect, ExplicitBitVect, UIntSparseIntVect],
 ) -> np.ndarray:
     """Convert rdkit fingerprint to numpy array.
 

--- a/datamol/isomers/_structural.py
+++ b/datamol/isomers/_structural.py
@@ -3,7 +3,6 @@ import collections
 from rdkit import Chem
 import datamol as dm
 
-
 IsomerReaction = collections.namedtuple(
     "IsomerReaction",
     ["name", "smarts", "reverse", "acyclic", "triplebond", "doublebond", "use"],

--- a/datamol/molar.py
+++ b/datamol/molar.py
@@ -1,11 +1,9 @@
-"""A set of utility functions to convert between various units and formats used in drug discovery.
-"""
+"""A set of utility functions to convert between various units and formats used in drug discovery."""
 
 from typing import Union
 from typing import Iterable
 
 import numpy as np
-
 
 _MOLAR_SCALES = {"M": 1, "mM": 1e-3, "uM": 1e-6, "nM": 1e-9, "pM": 1e-12, "fM": 1e-15}
 

--- a/datamol/predictors/esol.py
+++ b/datamol/predictors/esol.py
@@ -10,7 +10,6 @@ from ..descriptors.descriptors import mw
 from ..descriptors.descriptors import n_rotatable_bonds
 from ..descriptors.descriptors import n_aromatic_atoms_proportion
 
-
 _ESOL_INTERCEPT = 0.26121066137801696
 _ESOL_COEF = {
     "mw": -0.0066138847738667125,

--- a/datamol/reactions/_reactions.py
+++ b/datamol/reactions/_reactions.py
@@ -15,7 +15,6 @@ from rdkit.Chem import rdChemReactions
 
 import datamol as dm
 
-
 ATTACHING_RXN = rdChemReactions.ReactionFromSmarts("[*;h:1]>>[*:1][*]")
 
 

--- a/datamol/utils/fs.py
+++ b/datamol/utils/fs.py
@@ -1,5 +1,4 @@
-"""The `fs` module makes it easier to work with all type of path (the ones supported by `fsspec`).
-"""
+"""The `fs` module makes it easier to work with all type of path (the ones supported by `fsspec`)."""
 
 from typing import Union
 from typing import Optional

--- a/datamol/utils/perf.py
+++ b/datamol/utils/perf.py
@@ -2,7 +2,6 @@ import time
 
 from loguru import logger
 
-
 duration_intervals = (
     ("weeks", 604800),  # 60 * 60 * 24 * 7
     ("days", 86400),  # 60 * 60 * 24

--- a/datamol/viz/_lasso_highlight.py
+++ b/datamol/viz/_lasso_highlight.py
@@ -540,7 +540,7 @@ def lasso_highlight_image(
             # Extend target_color_list starting with the last color
             color_idx = target_color_list[-1] + 1 if target_color_list else 0
             target_color_list += [
-                (color_idx + i) % len(color_list) for i, _ enumerate(atom_indices_list_of_list)
+                (color_idx + i) % len(color_list) for i, _ in enumerate(atom_indices_list_of_list)
             ]
 
         atoms_idx_list.append(atom_idx_list)

--- a/datamol/viz/_lasso_highlight.py
+++ b/datamol/viz/_lasso_highlight.py
@@ -537,6 +537,12 @@ def lasso_highlight_image(
                 atom_indices_list_of_list = atom_indices
             atom_idx_list += atom_indices_list_of_list
 
+            # Extend target_color_list starting with the last color
+            color_idx = target_color_list[-1] + 1 if target_color_list else 0
+            target_color_list += [
+                (color_idx + i) % len(color_list) for i, _ enumerate(atom_indices_list_of_list)
+            ]
+
         atoms_idx_list.append(atom_idx_list)
         color_list_indexes.append(target_color_list)
 

--- a/datamol/viz/_lasso_highlight.py
+++ b/datamol/viz/_lasso_highlight.py
@@ -537,12 +537,6 @@ def lasso_highlight_image(
                 atom_indices_list_of_list = atom_indices
             atom_idx_list += atom_indices_list_of_list
 
-            # Extend target_color_list starting with the last color
-            color_idx = target_color_list[-1] + 1 if target_color_list else 0
-            target_color_list += [
-                (color_idx + i) % len(color_list) for i, _ in enumerate(atom_indices_list_of_list)
-            ]
-
         atoms_idx_list.append(atom_idx_list)
         color_list_indexes.append(target_color_list)
 


### PR DESCRIPTION
## Changelogs

Adds color to lasso when `atom_indices` are specified in addition or instead of `smarts_list`.

---

_Checklist:_

- [x] _Was this PR discussed in an issue? It is recommended to first discuss a new feature into a GitHub issue before opening a PR._
- [x] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation is a new function is added, or an existing one is deleted._
- [x] _Write concise and explanatory changelogs below._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

_discussion related to that PR_
https://github.com/datamol-io/datamol/issues/233

label: `bug`