### PR TITLE
fix: convert enforce_subs strings to Mol objects in fuzzy_scaffolding

### DIFF
--- a/datamol/scaffold/_fuzzy.py
+++ b/datamol/scaffold/_fuzzy.py
@@ -110,6 +110,17 @@ def fuzzy_scaffolding(
     if enforce_subs is None:
         enforce_subs = []
 
+    # Convert string substructures to RDKit Mol objects for use in GetSubstructMatch.
+    # The parameter accepts List[str] (SMILES or SMARTS) but GetSubstructMatch requires Mol.
+    enforce_subs_mols = []
+    for sub in enforce_subs:
+        if isinstance(sub, str):
+            mol_sub = Chem.MolFromSmarts(sub)
+            if mol_sub is not None:
+                enforce_subs_mols.append(mol_sub)
+        else:
+            enforce_subs_mols.append(sub)
+
     if additional_templates is None:
         additional_templates = []
 
@@ -220,11 +231,11 @@ def fuzzy_scaffolding(
             ]
 
             rgroups = [gp[f"R{k}"] for k in acceptable_groups if f"R{k}" in gp.keys()]
-            if enforce_subs is not None:
+            if enforce_subs_mols:
                 rgroups = [
                     rgp
                     for rgp in rgroups
-                    if not any([len(rgp.GetSubstructMatch(frag)) > 0 for frag in enforce_subs])
+                    if not any([len(rgp.GetSubstructMatch(frag)) > 0 for frag in enforce_subs_mols])
                 ]
             try:
                 scaff = trim_side_chain(mol, AdjustQueryProperties(core, core_query_param), rgroups)

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -33,3 +33,37 @@ def test_fuzzy_scaffolding():
     # the same length. the reason there are 3 not two is because it could have
     # extra columns where a cell may have none values.
     assert len(df_scf2groups.columns) == 3
+
+
+def test_fuzzy_scaffolding_with_enforce_subs():
+    """Test that enforce_subs accepts string (SMILES/SMARTS) arguments.
+
+    Regression test for https://github.com/datamol-io/datamol/issues/119
+    where passing strings to enforce_subs caused a TypeError in
+    GetSubstructMatch which expects an RDKit Mol object.
+    """
+    smiles = [
+        "Cc1ccc(NC(=O)Cn2cccn2)c(Br)c1",
+        "COc1ccc(OC(C)C(=O)N=c2sccn2C)cc1",
+        "CC(NC(=O)CSCc1cccs1)C1CCCO1",
+        "CC1CCCCN1C(=O)CN1CCC[C@@H](N)C1",
+        "COc1ccc(OC(C)C(=O)N=c2sccn2C)cc1",
+    ]
+
+    mols = [dm.to_mol(s) for s in smiles]
+
+    # Pass enforce_subs as strings (SMILES) — should not raise
+    all_scaffolds, df_scf2infos, df_scf2groups = dm.scaffold.fuzzy_scaffolding(
+        mols, enforce_subs=["c1ccccc1", "C1CCCO1"]
+    )
+
+    assert isinstance(all_scaffolds, set)
+    assert len(all_scaffolds) >= 1
+    assert len(df_scf2infos.index) == len(df_scf2groups.index)
+
+    # Pass enforce_subs as SMARTS strings — should also not raise
+    all_scaffolds2, _, _ = dm.scaffold.fuzzy_scaffolding(
+        mols, enforce_subs=["[cR1]1[cR1][cR1][cR1][cR1][cR1]1"]
+    )
+
+    assert isinstance(all_scaffolds2, set)


### PR DESCRIPTION
## Summary

Fixes `dm.scaffold.fuzzy_scaffolding()` crashing when `enforce_subs` is passed as a list of strings (SMILES or SMARTS).

The function signature declares `enforce_subs: Optional[List[str]]`, but line 227 passes each string element directly to `rgp.GetSubstructMatch(frag)`, which expects an RDKit `Mol` object — raising `ArgumentError` on any string input.

## Root Cause

```python
# Before (line 227): frag is a str from enforce_subs
rgp.GetSubstructMatch(frag)  # ArgumentError: str is not a Mol
```

`GetSubstructMatch` requires an RDKit `ROMol` query, not a Python string. The parameter type hint says `List[str]`, but the implementation assumed `Mol` objects.

## Fix

Convert string substructures to RDKit `Mol` objects via `Chem.MolFromSmarts()` early in the function, before they're used in `GetSubstructMatch`:

```python
enforce_subs_mols = []
for sub in enforce_subs:
    if isinstance(sub, str):
        mol_sub = Chem.MolFromSmarts(sub)
        if mol_sub is not None:
            enforce_subs_mols.append(mol_sub)
    else:
        enforce_subs_mols.append(sub)
```

Use `enforce_subs_mols` instead of `enforce_subs` in the `GetSubstructMatch` call.

## Test Output

```
tests/test_scaffold.py::test_fuzzy_scaffolding PASSED
tests/test_scaffold.py::test_fuzzy_scaffolding_with_enforce_subs PASSED
2 passed in 32.89s
```

### Before fix (demonstrating the bug):
```
ArgumentError: Python argument types in
    Mol.GetSubstructMatch(Mol, str)
did not match C++ signature:
    GetSubstructMatch(RDKit::ROMol self, RDKit::ROMol query, ...)
```

### After fix:
```
Success with Mol arg: (0, 1, 2, 3, 4, 5)
```

## Verification

- [x] Existing `test_fuzzy_scaffolding` still passes (no regression)
- [x] New `test_fuzzy_scaffolding_with_enforce_subs` passes with both SMILES and SMARTS strings
- [x] Confirmed original code raises `ArgumentError` with string args
- [x] Fix correctly converts strings to `Mol` via `MolFromSmarts`

Closes #119

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
